### PR TITLE
add support for nth-last pseudo class selectors

### DIFF
--- a/styled-xml-parser/src/main/java/com/itextpdf/styledxmlparser/css/selector/item/CssPseudoClassNthLastChildSelectorItem.java
+++ b/styled-xml-parser/src/main/java/com/itextpdf/styledxmlparser/css/selector/item/CssPseudoClassNthLastChildSelectorItem.java
@@ -23,28 +23,22 @@
 package com.itextpdf.styledxmlparser.css.selector.item;
 
 import com.itextpdf.styledxmlparser.css.CommonCssConstants;
-import com.itextpdf.styledxmlparser.node.ICustomElementNode;
-import com.itextpdf.styledxmlparser.node.IDocumentNode;
-import com.itextpdf.styledxmlparser.node.IElementNode;
 import com.itextpdf.styledxmlparser.node.INode;
+
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-class CssPseudoClassNthOfTypeSelectorItem extends CssPseudoClassNthSelectorItem {
+class CssPseudoClassNthLastChildSelectorItem extends CssPseudoClassNthSelectorItem {
 
-    CssPseudoClassNthOfTypeSelectorItem(String arguments) {
-        this(CommonCssConstants.NTH_OF_TYPE, arguments);
-    }
-
-    CssPseudoClassNthOfTypeSelectorItem(String pseudoClass, String arguments) {
-        super(pseudoClass, arguments);
+    CssPseudoClassNthLastChildSelectorItem(String arguments) {
+        super(CommonCssConstants.NTH_LAST_CHILD, arguments);
     }
 
     @Override
-    public boolean matches(INode node) {
-        if (!(node instanceof IElementNode) || node instanceof ICustomElementNode || node instanceof IDocumentNode) {
-            return false;
-        }
-        List<INode> children = getAllSiblingsOfNodeType(node);
-        return !children.isEmpty() && resolveNth(node, children);
+    protected boolean resolveNth(INode node, List<INode> children) {
+        final List<INode> reversedChildren = new ArrayList<>(children);
+        Collections.reverse(reversedChildren);
+        return super.resolveNth(node, reversedChildren);
     }
 }

--- a/styled-xml-parser/src/main/java/com/itextpdf/styledxmlparser/css/selector/item/CssPseudoClassNthLastOfTypeSelectorItem.java
+++ b/styled-xml-parser/src/main/java/com/itextpdf/styledxmlparser/css/selector/item/CssPseudoClassNthLastOfTypeSelectorItem.java
@@ -27,24 +27,22 @@ import com.itextpdf.styledxmlparser.node.ICustomElementNode;
 import com.itextpdf.styledxmlparser.node.IDocumentNode;
 import com.itextpdf.styledxmlparser.node.IElementNode;
 import com.itextpdf.styledxmlparser.node.INode;
+
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-class CssPseudoClassNthOfTypeSelectorItem extends CssPseudoClassNthSelectorItem {
+class CssPseudoClassNthLastOfTypeSelectorItem extends CssPseudoClassNthOfTypeSelectorItem {
 
-    CssPseudoClassNthOfTypeSelectorItem(String arguments) {
-        this(CommonCssConstants.NTH_OF_TYPE, arguments);
-    }
-
-    CssPseudoClassNthOfTypeSelectorItem(String pseudoClass, String arguments) {
-        super(pseudoClass, arguments);
+    CssPseudoClassNthLastOfTypeSelectorItem(String arguments) {
+        super(CommonCssConstants.NTH_LAST_OF_TYPE, arguments);
     }
 
     @Override
-    public boolean matches(INode node) {
-        if (!(node instanceof IElementNode) || node instanceof ICustomElementNode || node instanceof IDocumentNode) {
-            return false;
-        }
-        List<INode> children = getAllSiblingsOfNodeType(node);
-        return !children.isEmpty() && resolveNth(node, children);
+    protected boolean resolveNth(INode node, List<INode> children) {
+        final List<INode> reversedChildren = new ArrayList<>(children);
+        Collections.reverse(reversedChildren);
+        return super.resolveNth(node, reversedChildren);
     }
+
 }

--- a/styled-xml-parser/src/main/java/com/itextpdf/styledxmlparser/css/selector/item/CssPseudoClassSelectorItem.java
+++ b/styled-xml-parser/src/main/java/com/itextpdf/styledxmlparser/css/selector/item/CssPseudoClassSelectorItem.java
@@ -82,8 +82,12 @@ public abstract class CssPseudoClassSelectorItem implements ICssSelectorItem {
                 return CssPseudoClassLastOfTypeSelectorItem.getInstance();
             case CommonCssConstants.NTH_CHILD:
                 return new CssPseudoClassNthChildSelectorItem(arguments);
+            case CommonCssConstants.NTH_LAST_CHILD:
+                return new CssPseudoClassNthLastChildSelectorItem(arguments);
             case CommonCssConstants.NTH_OF_TYPE:
                 return new CssPseudoClassNthOfTypeSelectorItem(arguments);
+            case CommonCssConstants.NTH_LAST_OF_TYPE:
+                return new CssPseudoClassNthLastOfTypeSelectorItem(arguments);
             case CommonCssConstants.NOT:
                 CssSelector selector = new CssSelector(arguments);
                 for (ICssSelectorItem item : selector.getSelectorItems()) {

--- a/styled-xml-parser/src/test/java/com/itextpdf/styledxmlparser/css/selector/item/CssMatchesTest.java
+++ b/styled-xml-parser/src/test/java/com/itextpdf/styledxmlparser/css/selector/item/CssMatchesTest.java
@@ -82,6 +82,126 @@ public class CssMatchesTest extends ExtendedITextTest {
     }
 
     @Test
+    public void matchesNthChildFixSelectorItemTest() {
+        CssPseudoClassNthChildSelectorItem item = new CssPseudoClassNthChildSelectorItem("2");
+        IXmlParser htmlParser = new JsoupHtmlParser();
+        IDocumentNode documentNode = htmlParser.parse("<p>First</p><p>Second</p><p>Third</p><p>Fourth</p>");
+
+        INode bodyNode = documentNode
+                .childNodes().get(0)
+                .childNodes().get(1);
+        INode first = bodyNode.childNodes().get(0);
+        INode second = bodyNode.childNodes().get(1);
+        INode third = bodyNode.childNodes().get(2);
+        INode fourth = bodyNode.childNodes().get(3);
+
+        Assertions.assertFalse(item.matches(first), "First paragraph should NOT be matched, but matched!");
+        Assertions.assertTrue(item.matches(second), "Second paragraph should be matched, but WAS NOT matched!");
+        Assertions.assertFalse(item.matches(third), "Third paragraph should NOT be matched, but matched!");
+        Assertions.assertFalse(item.matches(fourth), "Fourth paragraph should NOT be matched, but matched!");
+    }
+
+    @Test
+    public void matchesNthChildEvenSelectorItemTest() {
+        CssPseudoClassNthChildSelectorItem item = new CssPseudoClassNthChildSelectorItem("2n");
+        IXmlParser htmlParser = new JsoupHtmlParser();
+        IDocumentNode documentNode = htmlParser.parse("<p>First</p><p>Second</p><p>Third</p><p>Fourth</p>");
+
+        INode bodyNode = documentNode
+                .childNodes().get(0)
+                .childNodes().get(1);
+        INode first = bodyNode.childNodes().get(0);
+        INode second = bodyNode.childNodes().get(1);
+        INode third = bodyNode.childNodes().get(2);
+        INode fourth = bodyNode.childNodes().get(3);
+
+        Assertions.assertFalse(item.matches(first), "First paragraph should NOT be matched, but matched!");
+        Assertions.assertTrue(item.matches(second), "Second paragraph should be matched, but WAS NOT matched!");
+        Assertions.assertFalse(item.matches(third), "Third paragraph should NOT be matched, but matched!");
+        Assertions.assertTrue(item.matches(fourth), "Fourth paragraph should be be matched, but WAS NOT matched!");
+    }
+
+    @Test
+    public void matchesNthChildOddSelectorItemTest() {
+        CssPseudoClassNthChildSelectorItem item = new CssPseudoClassNthChildSelectorItem("2n-1");
+        IXmlParser htmlParser = new JsoupHtmlParser();
+        IDocumentNode documentNode = htmlParser.parse("<p>First</p><p>Second</p><p>Third</p><p>Fourth</p>");
+
+        INode bodyNode = documentNode
+                .childNodes().get(0)
+                .childNodes().get(1);
+        INode first = bodyNode.childNodes().get(0);
+        INode second = bodyNode.childNodes().get(1);
+        INode third = bodyNode.childNodes().get(2);
+        INode fourth = bodyNode.childNodes().get(3);
+
+        Assertions.assertTrue(item.matches(first), "First paragraph should be matched, but WAS NOT matched!");
+        Assertions.assertFalse(item.matches(second), "Second paragraph should NOT be matched, but matched!");
+        Assertions.assertTrue(item.matches(third), "Third paragraph should be be matched, but WAS NOT matched!");
+        Assertions.assertFalse(item.matches(fourth), "Fourth paragraph should NOT be matched, but matched!");
+    }
+
+    @Test
+    public void matchesNthLastChildFixSelectorItemTest() {
+        CssPseudoClassNthLastChildSelectorItem item = new CssPseudoClassNthLastChildSelectorItem("2");
+        IXmlParser htmlParser = new JsoupHtmlParser();
+        IDocumentNode documentNode = htmlParser.parse("<p>First</p><p>Second</p><p>Third</p><p>Fourth</p>");
+
+        INode bodyNode = documentNode
+                .childNodes().get(0)
+                .childNodes().get(1);
+        INode first = bodyNode.childNodes().get(0);
+        INode second = bodyNode.childNodes().get(1);
+        INode third = bodyNode.childNodes().get(2);
+        INode fourth = bodyNode.childNodes().get(3);
+
+        Assertions.assertFalse(item.matches(first), "First paragraph should NOT be matched, but matched!");
+        Assertions.assertFalse(item.matches(second), "Second paragraph should NOT be matched, but matched!");
+        Assertions.assertTrue(item.matches(third), "Third paragraph should be matched, but WAS NOT matched!");
+        Assertions.assertFalse(item.matches(fourth), "Fourth paragraph should NOT be matched, but matched!");
+    }
+
+    @Test
+    public void matchesNthLastChildEvenSelectorItemTest() {
+        CssPseudoClassNthLastChildSelectorItem item = new CssPseudoClassNthLastChildSelectorItem("2n");
+        IXmlParser htmlParser = new JsoupHtmlParser();
+        IDocumentNode documentNode = htmlParser.parse("<p>First</p><p>Second</p><p>Third</p><p>Fourth</p>");
+
+        INode bodyNode = documentNode
+                .childNodes().get(0)
+                .childNodes().get(1);
+        INode first = bodyNode.childNodes().get(0);
+        INode second = bodyNode.childNodes().get(1);
+        INode third = bodyNode.childNodes().get(2);
+        INode fourth = bodyNode.childNodes().get(3);
+
+        Assertions.assertTrue(item.matches(first), "First paragraph should be matched, but WAS NOT matched!");
+        Assertions.assertFalse(item.matches(second), "Second paragraph should NOT be matched, but matched!");
+        Assertions.assertTrue(item.matches(third), "Third paragraph should be be matched, but WAS NOT matched!");
+        Assertions.assertFalse(item.matches(fourth), "Fourth paragraph should NOT be matched, but matched!");
+    }
+
+    @Test
+    public void matchesNthLastChildOddSelectorItemTest() {
+        CssPseudoClassNthLastChildSelectorItem item = new CssPseudoClassNthLastChildSelectorItem("2n-1");
+        IXmlParser htmlParser = new JsoupHtmlParser();
+        IDocumentNode documentNode = htmlParser.parse("<p>First</p><p>Second</p><p>Third</p><p>Fourth</p>");
+
+        INode bodyNode = documentNode
+                .childNodes().get(0)
+                .childNodes().get(1);
+        INode first = bodyNode.childNodes().get(0);
+        INode second = bodyNode.childNodes().get(1);
+        INode third = bodyNode.childNodes().get(2);
+        INode fourth = bodyNode.childNodes().get(3);
+
+        Assertions.assertFalse(item.matches(first), "First paragraph should NOT be matched, but matched!");
+        Assertions.assertTrue(item.matches(second), "Second paragraph should be matched, but WAS NOT matched!");
+        Assertions.assertFalse(item.matches(third), "Third paragraph should NOT be matched, but matched!");
+        Assertions.assertTrue(item.matches(fourth), "Fourth paragraph should be be matched, but WAS NOT matched!");
+    }
+
+    @Test
     public void matchesFirstOfTypeSelectorItemTest() {
         CssPseudoClassFirstOfTypeSelectorItem item = CssPseudoClassFirstOfTypeSelectorItem.getInstance();
         IXmlParser htmlParser = new JsoupHtmlParser();
@@ -126,6 +246,66 @@ public class CssMatchesTest extends ExtendedITextTest {
                     .childNodes().get(1);
 
         Assertions.assertTrue(item.matches(divNode));
+    }
+
+    @Test
+    public void matchesNthLastOfTypeFixSelectorItemTest() {
+        CssPseudoClassNthLastOfTypeSelectorItem item = new CssPseudoClassNthLastOfTypeSelectorItem("2");
+        IXmlParser htmlParser = new JsoupHtmlParser();
+        IDocumentNode documentNode = htmlParser.parse("<p>First</p><h1>Headline</h1><p>Second</p><h1>Headline</h1><p>Third</p><h1>Headline</h1><p>Fourth</p>");
+
+        INode bodyNode = documentNode
+                .childNodes().get(0)
+                .childNodes().get(1);
+        INode first = bodyNode.childNodes().get(0);
+        INode second = bodyNode.childNodes().get(2);
+        INode third = bodyNode.childNodes().get(4);
+        INode fourth = bodyNode.childNodes().get(6);
+
+        Assertions.assertFalse(item.matches(first), "First paragraph should NOT be matched, but matched!");
+        Assertions.assertFalse(item.matches(second), "Second paragraph should NOT be matched, but matched!");
+        Assertions.assertTrue(item.matches(third), "Third paragraph should be matched, but WAS NOT matched!");
+        Assertions.assertFalse(item.matches(fourth), "Fourth paragraph should NOT be be matched, but matched!");
+    }
+
+    @Test
+    public void matchesNthLastOfTypeEvenSelectorItemTest() {
+        CssPseudoClassNthLastOfTypeSelectorItem item = new CssPseudoClassNthLastOfTypeSelectorItem("2n");
+        IXmlParser htmlParser = new JsoupHtmlParser();
+        IDocumentNode documentNode = htmlParser.parse("<p>First</p><h1>Headline</h1><p>Second</p><h1>Headline</h1><p>Third</p><h1>Headline</h1><p>Fourth</p>");
+
+        INode bodyNode = documentNode
+                .childNodes().get(0)
+                .childNodes().get(1);
+        INode first = bodyNode.childNodes().get(0);
+        INode second = bodyNode.childNodes().get(2);
+        INode third = bodyNode.childNodes().get(4);
+        INode fourth = bodyNode.childNodes().get(6);
+
+        Assertions.assertTrue(item.matches(first), "First paragraph should be matched, but WAS NOT matched!");
+        Assertions.assertFalse(item.matches(second), "Second paragraph should NOT be matched, but matched!");
+        Assertions.assertTrue(item.matches(third), "Third paragraph should be matched, but WAS NOT matched!");
+        Assertions.assertFalse(item.matches(fourth), "Fourth paragraph should NOT be be matched, but matched!");
+    }
+
+    @Test
+    public void matchesNthLastOfTypeOddSelectorItemTest() {
+        CssPseudoClassNthLastOfTypeSelectorItem item = new CssPseudoClassNthLastOfTypeSelectorItem("2n-1");
+        IXmlParser htmlParser = new JsoupHtmlParser();
+        IDocumentNode documentNode = htmlParser.parse("<p>First</p><h1>Headline</h1><p>Second</p><h1>Headline</h1><p>Third</p><h1>Headline</h1><p>Fourth</p>");
+
+        INode bodyNode = documentNode
+                .childNodes().get(0)
+                .childNodes().get(1);
+        INode first = bodyNode.childNodes().get(0);
+        INode second = bodyNode.childNodes().get(2);
+        INode third = bodyNode.childNodes().get(4);
+        INode fourth = bodyNode.childNodes().get(6);
+
+        Assertions.assertFalse(item.matches(first), "First paragraph should NOT be matched, but matched!");
+        Assertions.assertTrue(item.matches(second), "Second paragraph should be matched, but WAS NOT matched!");
+        Assertions.assertFalse(item.matches(third), "Third paragraph should NOT be matched, but matched!");
+        Assertions.assertTrue(item.matches(fourth), "Fourth paragraph should be be matched, but WAS NOT matched!");
     }
 
     @Test


### PR DESCRIPTION
With this commit the following CSS3 pseudo classes will be supported:
- :nth-last-child(an+b) and
- :nth-last-of-type(2a+b)

This is especially helpful to format tables with a fixed number of columns, by using a combination of :nth-child and :nth-last-child.

Example, given the following markup:
```
<html>
<body>
  <table>
    <tr>
      <th>First Column</th>
      <th>Second Column</th>
      <th>Third Column</th>
      <th>Fourth Column</th>
      <th>Fifth Column</th>
    </tr>
    <tr>
      <td>Line 1a</td>
      <td>Line 1b</td>
      <td>Line 1c</td>
      <td>Line 1d</td>
      <td>Line 1e</td>
    </tr>
  </table>

  <table>
    <tr>
      <th>First Column</th>
      <th>Second Column</th>
      <th>Third Column</th>
      <th>Fourth Column</th>
    </tr>
    <tr>
      <td>Line 1a</td>
      <td>Line 1b</td>
      <td>Line 1c</td>
      <td>Line 1d</td>
    </tr>
  </table>
</body>
</html>
```

The following styles can be used to format the tables, such that the four-column table's last three columns will align with the last three columns of the five-column table:
```
table tr th:nth-child(1):nth-last-child(5) { width: 30%; }
table tr th:nth-child(2):nth-last-child(4) { width: 10%; }
table tr th:nth-child(3):nth-last-child(3) { width: 20%; }
table tr th:nth-child(4):nth-last-child(2) { width: 20%; }
table tr th:nth-child(5):nth-last-child(1) { width: 20%; }

table tr th:nth-child(1):nth-last-child(4) { width: 40%; }
table tr th:nth-child(2):nth-last-child(3) { width: 20%; }
table tr th:nth-child(3):nth-last-child(2) { width: 20%; }
table tr th:nth-child(4):nth-last-child(1) { width: 20%; }
```