### PR TITLE
Fix Typo in PdfA1Checker.CheckPageColorsUsages

### DIFF
--- a/pdfa/src/main/java/com/itextpdf/pdfa/checker/PdfA1Checker.java
+++ b/pdfa/src/main/java/com/itextpdf/pdfa/checker/PdfA1Checker.java
@@ -229,7 +229,7 @@ public class PdfA1Checker extends PdfAChecker {
      */
     @Override
     protected void checkPageColorsUsages(PdfDictionary pageDict, PdfDictionary pageResources) {
-        if ((!rgbUsedObjects.isEmpty() || !cmykUsedObjects.isEmpty() || grayUsedObjects.isEmpty())
+        if ((!rgbUsedObjects.isEmpty() || !cmykUsedObjects.isEmpty() || !grayUsedObjects.isEmpty())
                 && pdfAOutputIntentColorSpace == null) {
             throw new PdfAConformanceException(PdfaExceptionMessageConstant.IF_DEVICE_RGB_CMYK_GRAY_USED_IN_FILE_THAT_FILE_SHALL_CONTAIN_PDFA_OUTPUTINTENT);
         }


### PR DESCRIPTION
There seems to be a typo in PdfA1Checker.cs which fails PDF Documents which have no device dependent color spaces
(rgbUserObject,, cmykUsedObjects, grayUsedObjects all empty).

The PdfA2Check has it correct.

According to https://pdfa.org/wp-content/uploads/2011/08/tn0002_color_in_pdfa-1_2008-03-141.pdf it is not necessary to have an output intent, if e.g. only ICCBased colors are used.