### PR TITLE
Fix bug: dont remove parent just because children is empty

### DIFF
--- a/kernel/src/main/java/com/itextpdf/kernel/pdf/PdfOutline.java
+++ b/kernel/src/main/java/com/itextpdf/kernel/pdf/PdfOutline.java
@@ -339,7 +339,6 @@ public class PdfOutline {
             parentContent.put(PdfName.First, children.get(0).content);
             parentContent.put(PdfName.Last, children.get(children.size() - 1).content);
         } else {
-            parent.removeOutline();
             return;
         }
 


### PR DESCRIPTION
# Reason:

Currently there is a bug with `PdfOutline.removeOutline` function. Here is what happens in this bug:

If there is an outline like this:

```
Parent Outline
|- Child Outline
```
and, we remove `Child Outline`, then the parent outline automatically gets removed because the parent now has no children.

This is the relevant part of the code:

```java
if (children.size() > 0) {
    parentContent.put(PdfName.First, children.get(0).content);
    parentContent.put(PdfName.Last, children.get(children.size() - 1).content);
} else {
    parent.removeOutline();
    return;
}
  ```
  
  Hence, in this PR, I removed the line `parent.removeOutline();` so that the parent does not get removed.
