### PR TITLE
Include original exception

### DIFF
--- a/io/src/main/java/com/itextpdf/io/image/TiffImageHelper.java
+++ b/io/src/main/java/com/itextpdf/io/image/TiffImageHelper.java
@@ -266,7 +266,7 @@ class TiffImageHelper {
             if (rotation != 0)
                 tiff.image.setRotation(rotation);
         } catch (Exception e) {
-            throw new IOException(IoExceptionMessageConstant.CANNOT_READ_TIFF_IMAGE);
+            throw new IOException(IoExceptionMessageConstant.CANNOT_READ_TIFF_IMAGE, e);
         }
     }
 


### PR DESCRIPTION
Include original exception to know why the error is produced.

We are facing exceptions that end with this message when trying to create a PDF file from a TIFF image:

`
Caused by: com.itextpdf.io.IOException: Cannot read TIFF image.
	at com.itextpdf.io.image.TiffImageHelper.processTiffImage(TiffImageHelper.java:289)
	at com.itextpdf.io.image.TiffImageHelper.processImage(TiffImageHelper.java:92)
	at com.itextpdf.io.image.ImageDataFactory.createTiff(ImageDataFactory.java:431)
`